### PR TITLE
Fix listener janitor_events corruption of journaled_data

### DIFF
--- a/opensvc/daemon/listener.py
+++ b/opensvc/daemon/listener.py
@@ -487,11 +487,10 @@ class Listener(shared.OsvcThread):
                 if thr not in self.threads:
                     to_remove.append(idx)
                     continue
-                fevent = self.filter_event(event, thr)
+                # make a copy, filter_event may change data, avoid being replaced while queued
+                fevent = self.filter_event(json.loads(json.dumps(event)), thr)
                 if fevent is None:
                     continue
-                # make a copy to avoid being replaced while queued
-                fevent = json.loads(json.dumps(fevent))
                 if thr.h2conn:
                     if not thr.events_stream_ids:
                         to_remove.append(idx)


### PR DESCRIPTION
janitor_events() may have side effect on ['monitor', 'nodes', x, 'services', 'status', path] structure
during filter_daemon_status().

janitor_events()
 -> filter_event
   -> filter_patch_event
     -> filter_daemon_status(data, ...)
         alter data structure (which is daemon journaled_data)

Example: Having 'om mon -w' running, during daemon startup, or daemon join

 During 'om daemon join --node xxx', xxx node daemon will fail to apply patch because journaled_data
 altered without using journaled data function

 => stack
 ------------------------------- Patch Error ----------------------------------
 Path:
    ['monitor', 'nodes', 'node-6001']
 Patchset:
 => [['services', 'status', 'cluster', 'updated'], 1606230822.3565814]
    [['services', 'config', 'cluster', 'updated'], 1606230822.3460777]
    ...
    Exception Traceback (most recent call last):
      File "/usr/share/opensvc/opensvc/utilities/journaled_data.py", line 243, in _patch
        patch_fragment(patch)
      File "/usr/share/opensvc/opensvc/utilities/journaled_data.py", line 236, in patch_fragment
        self._set(path + _path, _value)
      File "/usr/share/opensvc/opensvc/utilities/journaled_data.py", line 194, in _set
        cursor = self.get_ref(path[:-1], self.data)
      File "/usr/share/opensvc/opensvc/utilities/journaled_data.py", line 138, in get_ref
        return reduce(operator.getitem, path, data)
    KeyError: 'cluster'