### PR TITLE
Allow restart terminated threads during rejoin or draining

### DIFF
--- a/opensvc/daemon/main.py
+++ b/opensvc/daemon/main.py
@@ -31,6 +31,9 @@ from .scheduler import Scheduler
 from core.node import Node
 from utilities.lazy import lazy, unset_lazy
 
+# node monitor status where start_threads is allowed
+START_THREADS_ALLOWED_NMON_STATUS = (None, "idle", "init", "rejoin", "draining")
+
 try:
     # with python3, select the forkserver method beacuse the
     # default fork method is unsafe from the daemon.
@@ -385,7 +388,7 @@ class Daemon(object):
             nmon_status = shared.DAEMON_STATUS.get(["monitor", "nodes", Env.nodename, "monitor", "status"])
         except (KeyError, TypeError):
             nmon_status = None
-        if nmon_status not in (None, "idle", "init"):
+        if nmon_status not in START_THREADS_ALLOWED_NMON_STATUS:
             return
 
         config_changed = self.read_config()


### PR DESCRIPTION
Allow restart terminated threads during rejoin or draining

This fix close a short period 'rejoin' or 'draining' where terminated daemon threads are not restarted automatically.

Previously opensvc main daemon can only detect terminated daemon threads when the node monitor status is:
- None
- idle
- init

Now terminated daemon threads will be also detected during 'rejoin' or 'draining' node monitor status.

Initial reason of limitation was: #01ad9b91a3f8f11c6c58c4bdb54688055343ea32

Same as allow threads starts when node monitor not in one of following status:
- shutting
- upgrade
- maintenance