### PR TITLE
Fix journaled_data corruption

### DIFF
--- a/opensvc/utilities/journaled_data.py
+++ b/opensvc/utilities/journaled_data.py
@@ -184,7 +184,7 @@ class JournaledData(object):
 
         self.emit(absolute_diff)
         if journal_diff:
-            self.push_diff(journal_diff)
+            self.push_diff_lk(journal_diff)
 
     def _set(self, path, value):
         """
@@ -295,7 +295,7 @@ class JournaledData(object):
         journal_diff = self._to_journal_diff(diff)
         self.emit(diff)
         if journal_diff:
-            self.push_diff(journal_diff)
+            self.push_diff_lk(journal_diff)
 
     def inc(self, path=None):
         with self.lock:
@@ -311,11 +311,11 @@ class JournaledData(object):
         self._set_lk(path=path, value=val)
         return val
 
-    def push_diff(self, diff):
+    def push_diff_lk(self, diff):
         """
         Concat a diff list to the in-flight diff list.
         """
-        self.diff += diff
+        self.diff += copy.deepcopy(diff)
 
     def pop_diff(self):
         """


### PR DESCRIPTION
full journaling example
---------------
* set(path=['a'], value={'b': 'B2'})
   => event {'kind': 'patch', 'id': 1, 'ts': 1607587980.607262, 'data': [[['a'], {'b': 'B2'}]]}
* set(path=['a', 'c'], value={'c1': 'C1', 'c2': 'C2'})
   => event {'kind': 'patch', 'id': 2, 'ts': 1607587980.6073081, 'data': [[['a', 'c'], {'c1': 'C1', 'c2': 'C2'}]]}
* merge(path=['a', 'c'], value={'c3': 'C3'})
   => event {'kind': 'patch', 'id': 3, 'ts': 1607587980.607347, 'data': [[['a', 'c', 'c3'], 'C3']]}

journal: [
   [['a'], {'b': 'B2', 'c': {'c1': 'C1', 'c2': 'C2', 'c3': 'C3'}}], <- instead of [['a'], {'b': 'B2'}],
   [['a', 'c'], {'c1': 'C1', 'c2': 'C2', 'c3': 'C3'}],              <- instead of [['a', 'c'], {'c1': 'C1', 'c2': 'C2'}],
   [['a', 'c', 'c3'], 'C3']
 ]