### PR TITLE
Fix 'om mon' stack, when called just after daemon startup

### DIFF
--- a/opensvc/tests/render/test_cluster.py
+++ b/opensvc/tests/render/test_cluster.py
@@ -1,0 +1,27 @@
+import pytest
+
+from env import Env
+from utilities.render.cluster import format_cluster
+
+
+@pytest.mark.ci
+class TestFormatCluster(object):
+    @staticmethod
+    def test_show_monitor_state_undef_when_monitor_has_not_yet_state(mocker):
+        mocker.patch.object(Env, "nodename", "node1")
+        output = format_cluster(node=[Env.nodename],
+                                data={"monitor": {"nodes": {}, "services": {}}})
+        assert output == """Threads              node1
+ daemon    running |      
+ monitor   undef  
+
+Nodes                node1
+ score             |      
+  load 15m         |      
+  mem              | -    
+  swap             | -    
+ compat    warn    |      
+ state             |      
+
+*/svc/*              node1
+"""

--- a/opensvc/utilities/render/cluster/__init__.py
+++ b/opensvc/utilities/render/cluster/__init__.py
@@ -518,6 +518,8 @@ def format_cluster(paths=None, node=None, data=None, prev_stats_data=None,
         out.append(line)
 
     def load_monitor(key, _data):
+        if "state" not in _data:
+            _data["state"] = "undef"
         if _data["state"] == "running":
             state = colorize(_data["state"], color.GREEN)
         else:


### PR DESCRIPTION
fixed stack:

      File "/usr/lib/python3.8/runpy.py", line 194, in _run_module_as_main
        return _run_code(code, main_globals, None,
      File "/usr/lib/python3.8/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/usr/share/opensvc/opensvc/__main__.py", line 125, in <module>
        ret = main(sys.argv)
      File "/usr/share/opensvc/opensvc/__main__.py", line 117, in main
        ret = main(argv=argv[1:])
      File "/usr/share/opensvc/opensvc/commands/svcmon.py", line 301, in main
        _main(node, argv)
      File "/usr/share/opensvc/opensvc/commands/svcmon.py", line 154, in _main
        svcmon(node, options)
      File "/usr/share/opensvc/opensvc/commands/svcmon.py", line 280, in svcmon
        outs = format_cluster(paths=expanded_svcs, node=nodes,
      File "/usr/share/opensvc/opensvc/utilities/render/cluster/__init__.py", line 1051, in format_cluster
        load_threads()
      File "/usr/share/opensvc/opensvc/utilities/render/cluster/__init__.py", line 686, in load_threads
        load_monitor(key, data[key])
      File "/usr/share/opensvc/opensvc/utilities/render/cluster/__init__.py", line 522, in load_monitor
        if _data["state"] == "running":
    KeyError: 'state'