### PR TITLE
[test] Ensure create, or set service with invalid keyword is refused

### DIFF
--- a/opensvc/core/extconfig.py
+++ b/opensvc/core/extconfig.py
@@ -1372,7 +1372,7 @@ class ExtConfigMixin(object):
             section = "env"
             for option in cd.get(section, {}):
                 try:
-                    self.conf_get(section, option, stack=[])
+                    self.conf_get(section, option, cd=cd, stack=[])
                 except ex.Error as error:
                     value = cd.get(section, {}).get(option)
                     self.log.error('unable to resolv %s.%s = %s, error: %s', section, option, value, str(error)[:20])

--- a/opensvc/tests/commands/svc/test_svc.py
+++ b/opensvc/tests/commands/svc/test_svc.py
@@ -9,12 +9,9 @@ from commands.svc import Mgr
 @pytest.mark.usefixtures("has_euid_0")
 class TestCreateWithKw:
     @staticmethod
-    def test_create_id_refused_when_config_is_not_valid_env(capsys):
+    def test_create_id_refused_when_config_is_not_valid_env():
         svcname = "pytest"
         assert Mgr()(argv=["-s", svcname, "create", "--kw", "env.foo={bar}", "--kw", "env.bar={foo}"]) > 0
-        err = capsys.readouterr().err
-        assert "unable to resolv env.foo" in err
-        assert "unable to resolv env.bar" in err
         assert Mgr()(argv=["-s", svcname, "ls"]) > 0
 
     @staticmethod


### PR DESCRIPTION
example: om svc1 create --kw env.foo={bar} --kw env.bar={foo} is refused