### PR TITLE
Fix last commit missing '--disable_rollback' during monitor provision

### DIFF
--- a/opensvc/daemon/monitor.py
+++ b/opensvc/daemon/monitor.py
@@ -1203,12 +1203,10 @@ class Monitor(shared.OsvcThread, MonitorObjectOrchestratorManualMixin):
     def service_provision(self, svc):
         self.set_smon(svc.path, "provisioning")
         leader = self.is_natural_leader(svc)
+        options = { "local": True }
         if leader:
-            cmd += ["--leader", "--disable-rollback"]
-        options = {
-            "local": True,
-            "leader": leader,
-        }
+            options["leader"] = leader
+            options["disable_rollback"] = True
         proc = self.service_action("provision", options=options, path=svc.path)
         self.push_proc(
             proc=proc,
@@ -1239,7 +1237,6 @@ class Monitor(shared.OsvcThread, MonitorObjectOrchestratorManualMixin):
             leader = self.is_natural_leader(svc)
         else:
             leader = Env.nodename == leader
-        cmd = ["unprovision"]
         options = {
             "local": True,
             "leader": leader,


### PR DESCRIPTION

o regression in #e34b795c4a8dcaacf5e559f9f5374480386516c0
  with stack
  Traceback (most recent call last):
    File "opensvc/daemon/monitor.py", line 712, in run
      self.do()
    File "opensvc/daemon/monitor.py", line 790, in do
      self.orchestrator()
    File "opensvc/daemon/monitor.py", line 1485, in orchestrator
      self.object_orchestrator(path, svc)
    File "opensvc/daemon/monitor.py", line 1720, in object_orchestrator
      self.object_orchestrator_manual(svc, smon, agg.avail)
    File "opensvc/daemon/monitor.py", line 125, in object_orchestrator_manual
      fn(**kwargs)
    File "opensvc/daemon/monitor.py", line 365, in _oom_provisioned
      step_provision()
    File "opensvc/daemon/monitor.py", line 359, in step_provision
      self.service_provision(svc)
    File "opensvc/daemon/monitor.py", line 1208, in service_provision
      cmd += ["--leader", "--disable-rollback"]
  UnboundLocalError: local variable 'cmd' referenced before assignment