### PR TITLE
Fix invalid exception on python2 during forkserver

### DIFF
--- a/opensvc/daemon/scheduler.py
+++ b/opensvc/daemon/scheduler.py
@@ -218,7 +218,7 @@ class Scheduler(shared.OsvcThread):
                 args=(path, action, options, now, session_id, cmd, )
             )
             proc.start()
-        except (FileNotFoundError, KeyboardInterrupt) as err:
+        except (OSError, KeyboardInterrupt) as err:
             self.log.warning("proc start cmd: %s failed with %s", cmd, str(err))
             return
         sigset = set(sigs)

--- a/opensvc/daemon/shared.py
+++ b/opensvc/daemon/shared.py
@@ -908,7 +908,7 @@ class OsvcThread(threading.Thread, Crypt):
                 args=(path, action, options, now, session_id, cmd)
             )
             proc.start()
-        except (FileNotFoundError, KeyboardInterrupt) as err:
+        except (OSError, KeyboardInterrupt) as err:
             self.log.warning("proc start cmd: %s failed with %s", cmd, str(err))
             return
         return proc


### PR DESCRIPTION
Commit #4869bffa5c250f4a9dcd40bc3f47d370e1f8d4ce use FileNotFoundError, not available on python2
use OSError instead

Initial stack was:
INFO n:node-2 c:scheduler | run 'om node collect_stats --cron'
ERROR n:node-2 c:scheduler | [Errno 2] No such file or directory
Traceback (most recent call last):
  File "/usr/share/opensvc/opensvc/daemon/scheduler.py", line 94, in run
    self.do()
  File "/usr/share/opensvc/opensvc/daemon/scheduler.py", line 121, in do
    self.dequeue_actions(now)
  File "/usr/share/opensvc/opensvc/daemon/scheduler.py", line 398, in dequeue_actions
    self.exec_action(task["sigs"], task["path"], task["action"], task["rids"], task["queued"], now, session_id)
  File "/usr/share/opensvc/opensvc/daemon/scheduler.py", line 220, in exec_action
    proc.start()
  File "python3.8/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
  File "python3.8/multiprocessing/context.py", line 291, in _Popen
    return Popen(process_obj)
  File "python3.8/multiprocessing/popen_forkserver.py", line 35, in __init__
    super().__init__(process_obj)
  File "python3.8/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "python3.8/multiprocessing/popen_forkserver.py", line 51, in _launch
    self.sentinel, w = forkserver.connect_to_new_process(self._fds)
  File "python3.8/multiprocessing/forkserver.py", line 88, in connect_to_new_process
    client.connect(self._forkserver_address)
FileNotFoundError: [Errno 2] No such file or directory

INFO n:node-2 c:monitor | svc2 monitor status change: idle => shutdown
INFO n:node-2 c:monitor | run 'om svc -s svc2 shutdown --local'
ERROR n:node-2 c:monitor | [Errno 2] No such file or directory
Traceback (most recent call last):
  File "/usr/share/opensvc/opensvc/daemon/monitor.py", line 714, in run
    self.do()
  File "/usr/share/opensvc/opensvc/daemon/monitor.py", line 792, in do
    self.orchestrator()
  File "/usr/share/opensvc/opensvc/daemon/monitor.py", line 1483, in orchestrator
    self.object_orchestrator(path, svc)
  File "/usr/share/opensvc/opensvc/daemon/monitor.py", line 1718, in object_orchestrator
    self.object_orchestrator_shutting(svc, smon, agg.avail)
  File "/usr/share/opensvc/opensvc/daemon/monitor.py", line 2040, in object_orchestrator_shutting
    self.service_shutdown(svc.path)
  File "/usr/share/opensvc/opensvc/daemon/monitor.py", line 1142, in service_shutdown
    proc = self.service_action("shutdown", options=options, path=path)
  File "/usr/share/opensvc/opensvc/daemon/shared.py", line 907, in service_action
    proc.start()
  File "python3.8/multiprocessing/process.py", line 121, in start
    self._popen = self._Popen(self)
  File "python3.8/multiprocessing/context.py", line 291, in _Popen
    return Popen(process_obj)
  File "python3.8/multiprocessing/popen_forkserver.py", line 35, in __init__
    super().__init__(process_obj)
  File "python3.8/multiprocessing/popen_fork.py", line 19, in __init__
    self._launch(process_obj)
  File "python3.8/multiprocessing/popen_forkserver.py", line 51, in _launch
    self.sentinel, w = forkserver.connect_to_new_process(self._fds)
  File "python3.8/multiprocessing/forkserver.py", line 88, in connect_to_new_process
    client.connect(self._forkserver_address)
FileNotFoundError: [Errno 2] No such file or directory