### PR TITLE
svc log: add parameter --sid

### DIFF
--- a/opensvc/commands/mgr/parser.py
+++ b/opensvc/commands/mgr/parser.py
@@ -266,6 +266,11 @@ OPT = Storage({
         action="store_true", dest="show_disabled",
         help="Include the disabled resources. This option supersedes "
              "the :kw:`show_disabled` value in the service configuration."),
+    "sid": Option(
+        "--sid", default=None,
+        action="store", dest="sid",
+        help="Session id to filter "
+             "from the log file tail. Default is None."),
     "slave": Option(
         "--slave", default=None, action="store", dest="slave",
         help="Limit the action to the service resources in the specified, comma-"
@@ -400,6 +405,7 @@ ACTIONS = {
                 OPT.backlog,
                 OPT.follow,
                 OPT.nopager,
+                OPT.sid,
             ]
         },
         "ls": {

--- a/opensvc/core/objects/svc.py
+++ b/opensvc/core/objects/svc.py
@@ -1965,12 +1965,13 @@ class BaseSvc(Crypt, ExtConfigMixin):
     # daemon communications
     #
     #########################################################################
-    def daemon_backlogs(self, server=None, node=None, backlog=None, debug=False):
+    def daemon_backlogs(self, server=None, node=None, backlog=None, sid=None, debug=False):
         req = {
             "action": "object_backlogs",
             "options": {
                 "path": self.path,
                 "backlog": backlog,
+                "sid": sid,
                 "debug": debug,
             }
         }
@@ -2250,7 +2251,7 @@ class BaseSvc(Crypt, ExtConfigMixin):
         nodes = self.node.nodes_selector(node)
         auto = sorted(nodes, reverse=True)
         self._backlogs(server=self.options.server, node=node,
-                       backlog=self.options.backlog,
+                       backlog=self.options.backlog, sid=self.options.sid,
                        debug=self.options.debug,
                        auto=auto)
         if not self.options.follow:
@@ -2265,10 +2266,10 @@ class BaseSvc(Crypt, ExtConfigMixin):
                 # broken pipe
                 return
 
-    def _backlogs(self, server=None, node=None, backlog=None, debug=False, auto=None):
+    def _backlogs(self, server=None, node=None, backlog=None, sid=None, debug=False, auto=None):
         from utilities.render.color import colorize_log_line
         lines = []
-        for line in self.daemon_backlogs(server, node, backlog, debug):
+        for line in self.daemon_backlogs(server, node, backlog, sid, debug):
             try:
                 line = colorize_log_line(line, auto=auto)
             except Exception as exc:

--- a/opensvc/daemon/handlers/object/backlogs/get.py
+++ b/opensvc/daemon/handlers/object/backlogs/get.py
@@ -26,6 +26,13 @@ class Handler(daemon.handler.BaseHandler):
             "default": "10k",
             "desc": "The per-instance backlog size.",
         },
+        {
+            "name": "sid",
+            "required": False,
+            "format": "string",
+            "default": None,
+            "desc": "The session id to filter from the log file tail.",
+        },
     ]
     access = {
         "roles": ["guest"],
@@ -39,5 +46,5 @@ class Handler(daemon.handler.BaseHandler):
             raise ex.HTTP(404, "%s not found" % options.path)
         logfile = os.path.join(svc.log_d, svc.name+".log")
         ofile = thr._action_logs_open(logfile, options.backlog, svc.path)
-        return thr.read_file_lines(ofile)
+        return thr.read_file_lines(ofile, options.sid)
 

--- a/opensvc/daemon/listener.py
+++ b/opensvc/daemon/listener.py
@@ -2038,7 +2038,7 @@ class ClientHandler(shared.OsvcThread):
             line = ofile.readline()
         return ofile
 
-    def read_file_lines(self, ofile):
+    def read_file_lines(self, ofile, sid=None):
         data = []
         buff = ""
         def parse(_buff):
@@ -2065,7 +2065,12 @@ class ClientHandler(shared.OsvcThread):
                 if buff:
                     # new msg, push pending buff
                     try:
-                        data.append(parse(buff))
+                        parse_data = parse(buff)
+                        if sid:
+                            if parse_data["x"]["sid"] == sid:
+                                data.append(parse_data)
+                        else:
+                            data.append(parse_data)
                     except ValueError:
                         pass
                 buff = line
@@ -2074,7 +2079,10 @@ class ClientHandler(shared.OsvcThread):
         if buff:
             # EOF, push pending buff
             try:
-                data.append(parse(buff))
+                parse_data = parse(buff)
+                if sid and parse_data["x"]["sid"] != sid:
+                    return data
+                data.append(parse_data)
             except ValueError:
                 pass
         return data


### PR DESCRIPTION
retrieve log for a sid : `om svc --sid=<sid>`
object_backlogs route takes 'sid' parameter
`/object_backlogs?path=<path>&sid=<sid>`